### PR TITLE
More verbose and better permission error handling

### DIFF
--- a/src/certifi/__main__.py
+++ b/src/certifi/__main__.py
@@ -10,14 +10,18 @@ parser.add_argument("-v", "--verbose", action="store_true")
 parser.add_argument("--system-store", action="store_true")
 args = parser.parse_args()
 
+try:
+    _patched, _css_dist_info, _certifi_dist_info = _patch_dist_info()
+except OSError as e:
+    parser.exit(3, f"Failed to patch certifi's dist-info: {e}\n")
 
-_patched = _patch_dist_info()
 if args.verbose:
     print(f"certifi-system store {__version__}")
     if _patched:
-        print("Patched certifi.dist-info -> certifi_system_store.dist-info")
+        print("Successfully patched certifi's dist-info")
     else:
         print("certifi.dist-info already patched")
+    print(f"{_certifi_dist_info} -> {_css_dist_info}")
 
 if args.contents:
     print(contents())


### PR DESCRIPTION
- Nicer error message when user does not have permission to write
  dist-info
- Show base directory for all OSErrors (including PermissionError)
- Print absolute symlink paths in verbose mode
- Verify that symlink is created in right site-packages

See: https://github.com/tiran/certifi-system-store/issues/8
Signed-off-by: Christian Heimes <christian@python.org>