### PR TITLE
Refactor tests to use py3-*

### DIFF
--- a/.github/entry.sh
+++ b/.github/entry.sh
@@ -14,4 +14,4 @@ fi
 
 # update to latest setuptools, pipm and tox
 python3 -m pip install --upgrade pip setuptools tox
-python3 -m tox --skip-missing-interpreters
+python3 -m tox -e py3-test,py3-requests

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -23,7 +23,7 @@ jobs:
       - name: checkout
         uses: "actions/checkout@v2"
       - name: Run test in FreeBSD VM
-        uses: vmactions/freebsd-vm@v0.1.2
+        uses: "vmactions/freebsd-vm@v0.1.2"
         with:
           usesh: true
           prepare: pkg install -y python37 ca_root_nss
@@ -33,4 +33,6 @@ jobs:
             python3.7 -m ensurepip
             python3.7 -m pip install --upgrade pip setuptools tox
             uname -a
-            python3.7 -m tox --skip-missing-interpreters -e py37-test,py37-requests
+            python3.7 -m tox -e py3-test,py3-requests
+            # avoid output spam by "get back by rsync" feature
+            rm -rf .tox

--- a/tox.ini
+++ b/tox.ini
@@ -2,21 +2,14 @@
 envlist = lint,py{36,37,38,39,310}-{test,requests},pypy3
 isolated_build = True
 
-[testenv:py{36,37,38,39,310}-simple]
+[testenv:py{3,36,37,38,39,310,py3}-test]
 extras = tests
 recreate = True
 commands =
     python -m certifi -v
     python -m pytest {posargs}
 
-[testenv:py{36,37,38,39,310}-test]
-extras = tests
-recreate = True
-commands =
-    python -m certifi -v
-    python -m pytest {posargs}
-
-[testenv:py{36,37,38,39,310}-requests]
+[testenv:py{3,36,37,38,39,310,py3}-requests]
 extras = tests, requests
 recreate = True
 commands =


### PR DESCRIPTION
py3 is an alias for current python3 interpreter.

Signed-off-by: Christian Heimes <christian@python.org>