### PR TITLE
Wheel copytree hack

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,38 @@
+import os
+import shutil
 from setuptools import setup
 
-setup()
+cmdclass = {}
+
+try:
+    from wheel.bdist_wheel import bdist_wheel, wheel_version
+except ImportError:
+    pass
+else:
+
+    class custom_bdist_wheel(bdist_wheel):
+        def add_hack(self, css_distinfo):
+            if not css_distinfo.endswith(".dist-info"):
+                raise ValueError(css_distinfo)
+            directory, distinfo = os.path.split(css_distinfo)
+            certifi_distinfo = os.path.join(
+                directory, distinfo.replace("certifi_system_store", "certifi")
+            )
+            if os.path.isdir(certifi_distinfo):
+                shutil.rmtree(certifi_distinfo)
+            shutil.copytree(css_distinfo, certifi_distinfo)
+
+            # _relsymlink(distinfo_path, certifi_distinfo)
+            # print(distinfo_path, certifi_distinfo)
+            # raise ValueError(egginfo_path, distinfo_path)
+
+        def write_wheelfile(
+            self, wheelfile_base, generator="bdist_wheel (" + wheel_version + ")"
+        ):
+            super().write_wheelfile(wheelfile_base, generator)
+            self.add_hack(wheelfile_base)
+
+    cmdclass["bdist_wheel"] = custom_bdist_wheel
+
+
+setup(cmdclass=cmdclass)

--- a/src/certifi/_patch.py
+++ b/src/certifi/_patch.py
@@ -45,7 +45,9 @@ def _patch_dist_info():
     abs_certifi_distinfodir = os.path.join(css_basedir, certifi_distinfodir)
 
     # create symlink certifi.dist-info -> certifi_system_store.dist-info
-    _relsymlink(target=abs_css_distinfodir, linkname=abs_certifi_distinfodir)
+    # copy tree
+    shutil.copytree(abs_css_distinfodir, abs_certifi_distinfodir)
+    # _relsymlink(target=abs_css_distinfodir, linkname=abs_certifi_distinfodir)
 
     # get dist info from refreshed working set
     css_dist = pkg_resources.get_distribution("certifi_system_store")


### PR DESCRIPTION
Attempt to hack wheel files. pip doesn't like the hack: ``pip._internal.exceptions.UnsupportedWheel: multiple .dist-info directories found: certifi-3021.3.16.dist-info, certifi_system_store-3021.3.16.dist-info``