### PR TITLE
Add missing install_requires on setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ zip_safe = True
 setup_requires = setuptools
 # hack to prevent installation on unsupported platforms Windows and macOS
 install_requires =
+    setuptools
     certifi-system-store > 4000; sys_platform == "win32" or sys_platform == "darwin"
 python_requires = >=3.6
 


### PR DESCRIPTION
This package is using pkg_resources explicitly, it should therefore
declare an explicit dependency on setuptools.  The missing dependency
has lead me to actually miss the runtime dependency which caused issues
for Gentoo users for whom setuptools were cleaned.